### PR TITLE
fix: material editor issue

### DIFF
--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<Material> MaterialLibrary::saveMaterial(const std::shared_ptr<Ma
         stream.setGenerateByteOrderMark(true);
 
         // Write the contents
-        material->setName(info.fileName().remove(QStringLiteral(".FCMat"), Qt::CaseInsensitive));
+        material->setName(info.fileName().remove(QStringLiteral(".FCMat"),Qt::CaseInsensitive));
         material->setLibrary(getptr());
         material->setDirectory(getRelativePath(path));
         material->save(stream, overwrite, saveAsCopy, saveInherited);


### PR DESCRIPTION
-Changed info.baseName() to
info.fileName().remove(QStringLiteral(".FCMat"), Qt::CaseInsensitive) 
in MaterialLibrary.cpp to ensure that only the extension ".FCmat" is 
removed from the file name bacause the previous version was 
removing everything in front of the first dot